### PR TITLE
css @supports has been replaced by @media

### DIFF
--- a/src/skin/css/main.css
+++ b/src/skin/css/main.css
@@ -18,9 +18,9 @@
 		padding-left: 4px !important;
 	}	
 
-	@supports -moz-bool-pref('extensions.roomybookmarkstoolbar.autoHideBar'){
-		#PersonalToolbar[collapsed="true"] #personal-bookmarks{
-			visibility: hidden;
+	@media (-moz-bool-pref: 'extensions.roomybookmarkstoolbar.autoHideBar'){
+		#PersonalToolbar[collapsed="true"] {
+			visibility: hidden !important;
 		}
 	}
 }


### PR DESCRIPTION
@p1usminus 
This cause PersonalToolbar been unload when collapsed. And have to be reload when expanded. Which is problematic. 