### PR TITLE
Fixed wrong hide behaviours due to extension popup change 

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,4 +1,5 @@
 const { AddonManager } = ChromeUtils.importESModule("resource://gre/modules/AddonManager.sys.mjs");
+const { CustomizableUI } = ChromeUtils.importESModule("moz-src:///browser/components/customizableui/CustomizableUI.sys.mjs");
 
 var Globals = {};
 
@@ -74,11 +75,7 @@ function install(data, reason) {
 function uninstall() { }
 
 async function startup(data, reason) {
-  var temp = {};
-  Services.scriptloader.loadSubScript("chrome://roomybookmarkstoolbar/content/prefs.js", temp, 'UTF-8');
-  delete temp;
-
-  const { CustomizableUI } = ChromeUtils.importESModule("moz-src:///browser/components/customizableui/CustomizableUI.sys.mjs");
+  Services.scriptloader.loadSubScript("chrome://roomybookmarkstoolbar/content/prefs.js", {}, 'UTF-8');
 
   try {
     CustomizableUI.createWidget({

--- a/src/content/overlay.js
+++ b/src/content/overlay.js
@@ -5,10 +5,10 @@ MozXULElement.parseXULToFragment(`
 		insertafter="placesContext_delete"/>
 	<menuitem id="rbtChangeColor"
 		label="&roomybookmarkstoolbar.overlay.rbtChangeColor.label;"
-		oncommand="roomybookmarkstoolbar.openColorMenu()"
 		insertafter="rbtSeparator"/>
 `,["chrome://roomybookmarkstoolbar/locale/overlay.dtd"]),
 document.getElementById('placesContext_delete').nextSibling);
+document.getElementById('rbtChangeColor').addEventListener('command', _ => { roomybookmarkstoolbar.openColorMenu() });
 
 let toolbarVisible; // Save visibility of toolbar before any location changes
 

--- a/src/content/overlay.js
+++ b/src/content/overlay.js
@@ -90,7 +90,7 @@ var roomybookmarkstoolbar = {
 		}
 		this.timeOutHide = null;
 
-		if (!roomybookmarkstoolbar.PersonalToolbar.collapsed && !hovered && !popup) {
+		if (roomybookmarkstoolbar.autohide &&!roomybookmarkstoolbar.PersonalToolbar.collapsed && !hovered && !popup) {
 			toolbarVisible = false;
 			this.timeOutHide = setTimeout(roomybookmarkstoolbar.setVisibly, roomybookmarkstoolbar.hideBarTime);
 		} else {
@@ -109,7 +109,7 @@ var roomybookmarkstoolbar = {
 					await PlacesToolbarHelper._resetView();
 				}
 				//document.getElementById('PlacesToolbar')._placesView._updateNodesVisibilityTimerCallback();
-				document.getElementById('PlacesToolbar')?._placesView.updateNodesVisibility();
+				document.getElementById('PlacesToolbar')?._placesView?.updateNodesVisibility();
 			}
 		}
 	},
@@ -225,7 +225,9 @@ var roomybookmarkstoolbar = {
 		var rbtlibbutton = document.getElementById("rbtlibbutton");
 		var backButton = document.getElementById("back-button");
 		var menuButton = document.getElementById("PanelUI-menu-button");
-		var barContextMenu = document.getElementById("placesContext");
+		var mainPopupSet = document.getElementById("mainPopupSet");
+		var MPSEventHandler = (e) => {if(["customizationui-widget-panel","placesContext"].includes(e.target.id))
+			if(e.type == "popupshown") this.onPopupshown(); else if(e.type == "popuphidden") this.onPopuphidden();};
 
 		if (register) {
 			if (type) {
@@ -244,7 +246,7 @@ var roomybookmarkstoolbar = {
 				}
 				// toolbox.addEventListener("popupshown", this.onPopupshown, false);
 				// toolbox.addEventListener("popuphidden", this.onPopuphidden, false);
-				try { barContextMenu.addEventListener("popupshown", this.onPopupshown, false); } catch (e) { }
+				try { mainPopupSet.addEventListener("popupshown", MPSEventHandler, false); } catch (e) { }
 			} else {
 				try { toolbox.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { }
 				if (!autoHideZoneAll) {
@@ -256,7 +258,7 @@ var roomybookmarkstoolbar = {
 					if (autoHideZoneBackButton) { try { backButton.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { } }
 					if (autoHideZoneMenuButton) { try { menuButton.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { } }
 				} else roomybookmarkstoolbar.toolboxOver = true;
-				try { barContextMenu.addEventListener("popuphidden", this.onPopuphidden, false); } catch (e) { }
+				try { mainPopupSet.addEventListener("popuphidden", MPSEventHandler, false); } catch (e) { }
 			}
 		} else {
 			// toolbox.removeEventListener("mousemove", roomybookmarkstoolbar.onMouseMove, false)
@@ -270,7 +272,7 @@ var roomybookmarkstoolbar = {
 				try { backButton.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
 				try { menuButton.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
 				try { toolbox.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
-				try { barContextMenu.removeEventListener("popupshown", this.onPopupshown, false); } catch (e) { }
+				try { mainPopupSet.removeEventListener("popupshown", MPSEventHandler, false); } catch (e) { }
 			} else {
 				PersonalToolbar.removeEventListener("mouseleave", this.onMouseOutput, false);
 				try { navBar.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
@@ -280,7 +282,7 @@ var roomybookmarkstoolbar = {
 				try { backButton.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
 				try { menuButton.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
 				try { toolbox.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
-				try { barContextMenu.removeEventListener("popuphidden", this.onPopuphidden, false); } catch (e) { }
+				try { mainPopupSet.removeEventListener("popuphidden", MPSEventHandler, false); } catch (e) { }
 			}
 		}
 	},

--- a/src/content/overlay.js
+++ b/src/content/overlay.js
@@ -19,7 +19,6 @@ var progressListener = {
 		if (roomybookmarkstoolbar.autohide) {
 			// This is like a secondary autoHideBookmarksBar function, just for tab switching
 			if (!(aFlags & Ci.nsIWebProgressListener.LOCATION_CHANGE_SAME_DOCUMENT)) {
-				// roomybookmarkstoolbar.hideBookmarksBar(!toolbarVisible);
 				roomybookmarkstoolbar.setVisibly();
 			}
 		}
@@ -40,9 +39,6 @@ var roomybookmarkstoolbar = {
 
 	register: function () {
 		this.branch = Services.prefs.getBranch("extensions.roomybookmarkstoolbar.");
-		/* if (!("addObserver" in this.branch)) {
-			this.branch.QueryInterface(Components.interfaces.nsIPrefBranch2);
-		} */
 		this.branch.addObserver("", this, false);
 	},
 
@@ -108,7 +104,6 @@ var roomybookmarkstoolbar = {
 				if (typeof document.getElementById('PlacesToolbar')._placesView == 'undefined') {
 					await PlacesToolbarHelper._resetView();
 				}
-				//document.getElementById('PlacesToolbar')._placesView._updateNodesVisibilityTimerCallback();
 				document.getElementById('PlacesToolbar')?._placesView?.updateNodesVisibility();
 			}
 		}
@@ -116,7 +111,6 @@ var roomybookmarkstoolbar = {
 
 	onMouseOver: function (e) {
 		roomybookmarkstoolbar.lastY = null;
-		// var toolbox = document.getElementById("navigator-toolbox");
 
 		if (roomybookmarkstoolbar.autohide) {
 			if (roomybookmarkstoolbar.timeOutHide) {
@@ -128,7 +122,6 @@ var roomybookmarkstoolbar = {
 			roomybookmarkstoolbar.hideHandler();
 		}
 
-		// try { toolbox.removeEventListener("mousemove", roomybookmarkstoolbar.onMouseMove, false); } catch (e) { }
 		roomybookmarkstoolbar.mouseMoveListenerhandler(false);
 	},
 
@@ -139,11 +132,9 @@ var roomybookmarkstoolbar = {
 			if (!roomybookmarkstoolbar.toolboxOver) {
 				var toolbox = document.getElementById("navigator-toolbox");
 
-				// toolbox.addEventListener("mousemove", roomybookmarkstoolbar.onMouseMove, false);
 				roomybookmarkstoolbar.mouseMoveListenerhandler(true);
 
 				if (e.target == toolbox) roomybookmarkstoolbar.timeOutHide = setTimeout(roomybookmarkstoolbar.hideHandler, 100);
-				// else e.stopPropagation ();
 			}
 			else roomybookmarkstoolbar.hideHandler();
 
@@ -152,10 +143,8 @@ var roomybookmarkstoolbar = {
 
 	onMouseMove: function (e) {
 		if (e.target == document.getElementById("PanelUI-button")) return;
-		// var toolbox = document.getElementById("navigator-toolbox");
 
 		if (roomybookmarkstoolbar.PersonalToolbar.collapsed || !roomybookmarkstoolbar.autohide) {
-			// try { toolbox.removeEventListener("mousemove", roomybookmarkstoolbar.onMouseMove, false); } catch (e) { }
 			roomybookmarkstoolbar.mouseMoveListenerhandler(false);
 			roomybookmarkstoolbar.lastY = null;
 			return;
@@ -172,31 +161,21 @@ var roomybookmarkstoolbar = {
 			if (y > roomybookmarkstoolbar.lastY) {
 				roomybookmarkstoolbar.lastY = null;
 				roomybookmarkstoolbar.hideHandler();
-				// try { toolbox.removeEventListener("mousemove", roomybookmarkstoolbar.onMouseMove, false); } catch (e) { }
 				roomybookmarkstoolbar.mouseMoveListenerhandler(false);
 			}
 		}
 		roomybookmarkstoolbar.lastY = y;
 	},
 
-	onPopupshown: function (e) {
+	onpopupshown: function (e) {
 		roomybookmarkstoolbar.popup = true;
 		roomybookmarkstoolbar.hideHandler();
 	},
 
-	onPopuphidden: function (e) {
+	onpopuphidden: function (e) {
 		roomybookmarkstoolbar.popup = false;
 		roomybookmarkstoolbar.hideHandler();
 	},
-
-	// onMouseOverFix: function (e) {		//Fix problem with wrong hide, when enabled menu\nav bar\tabs
-	// 	if (this.timeOutHide) {
-	// 		clearTimeout(this.timeOutHide);
-	// 	}
-	// 	this.timeOutHide = null;
-	// 	roomybookmarkstoolbar.toolboxOver = true;
-	// 	roomybookmarkstoolbar.hideHandler(false, true);
-	// },
 
 	mouseMoveListenerhandler: function (on) {
 		var toolbox = document.getElementById("navigator-toolbox");
@@ -226,14 +205,12 @@ var roomybookmarkstoolbar = {
 		var backButton = document.getElementById("back-button");
 		var menuButton = document.getElementById("PanelUI-menu-button");
 		var mainPopupSet = document.getElementById("mainPopupSet");
-		var MPSEventHandler = (e) => {if(["customizationui-widget-panel","placesContext"].includes(e.target.id))
-			if(e.type == "popupshown") this.onPopupshown(); else if(e.type == "popuphidden") this.onPopuphidden();};
+		var MPSEventHandler = (e) => {if(["customizationui-widget-panel","placesContext"].includes(e.target.id)) this["on" + e.type]();};
 
 		if (register) {
 			if (type) {
 				if (autoHideZoneAll) {
 					toolbox.addEventListener("mouseenter", this.onMouseOver, false);
-					// toolbox.addEventListener("mouseenter", this.onMouseOverFix, false);
 				} else {
 					PersonalToolbar.addEventListener("mouseenter", this.onMouseOver, false);
 					if (autoHideZoneNav) { try { navBar.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
@@ -242,10 +219,7 @@ var roomybookmarkstoolbar = {
 					if (autoHideZoneButton) { try { rbtlibbutton.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
 					if (autoHideZoneBackButton) { try { backButton.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
 					if (autoHideZoneMenuButton) { try { menuButton.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
-					// try { toolbox.addEventListener("mouseenter", this.onMouseOverFix, false);} catch(e) {}
 				}
-				// toolbox.addEventListener("popupshown", this.onPopupshown, false);
-				// toolbox.addEventListener("popuphidden", this.onPopuphidden, false);
 				try { mainPopupSet.addEventListener("popupshown", MPSEventHandler, false); } catch (e) { }
 			} else {
 				try { toolbox.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { }
@@ -261,7 +235,6 @@ var roomybookmarkstoolbar = {
 				try { mainPopupSet.addEventListener("popuphidden", MPSEventHandler, false); } catch (e) { }
 			}
 		} else {
-			// toolbox.removeEventListener("mousemove", roomybookmarkstoolbar.onMouseMove, false)
 			roomybookmarkstoolbar.mouseMoveListenerhandler(false);
 			if (type) {
 				PersonalToolbar.removeEventListener("mouseenter", this.onMouseOver, false);
@@ -444,28 +417,9 @@ var roomybookmarkstoolbar = {
 	},
 
 	BBonNewTab: function () {
-		// var tabContainer = gBrowser.tabContainer;
-
-		// function hideBBonPage() {
-		// 	if (roomybookmarkstoolbar.branch.getBoolPref('BBonNewTab')) {
-		// 		var tabUrl = gBrowser.currentURI.scheme;
-		// 		if (tabUrl == 'about' || tabUrl == 'chrome') {
-		// 			roomybookmarkstoolbar.hideBookmarksBar(false);
-		// 		} else {
-		// 			roomybookmarkstoolbar.PersonalToolbar.collapsed = true;
-		// 		}
-		// 	}
-		// }
-
 		if (this.branch.getBoolPref('BBonNewTab')) {
 			Services.prefs.setCharPref("browser.toolbars.bookmarks.visibility", "newtab");
-			// tabContainer.removeEventListener("TabSelect", hideBBonPage, false);
-			// tabContainer.addEventListener("TabSelect", hideBBonPage, false);
-			// tabContainer.removeEventListener("TabAttrModified", hideBBonPage, false);
-			// tabContainer.addEventListener("TabAttrModified", hideBBonPage, false);
 		} else {
-			// tabContainer.removeEventListener("TabSelect", hideBBonPage, false);
-			// tabContainer.removeEventListener("TabAttrModified", hideBBonPage, false);
 			if (!this.branch.getBoolPref('autoHideBar') && !this.branch.getBoolPref('hideByDefault')) {
 				this.hideBookmarksBar(false);
 				Services.prefs.setCharPref("browser.toolbars.bookmarks.visibility", "always");

--- a/src/content/overlay.js
+++ b/src/content/overlay.js
@@ -207,56 +207,20 @@ var roomybookmarkstoolbar = {
 		var mainPopupSet = document.getElementById("mainPopupSet");
 		var MPSEventHandler = (e) => {if(["customizationui-widget-panel","placesContext"].includes(e.target.id)) this["on" + e.type]();};
 
+		var E, H, P, T = type ? (E = "mouseenter", H = this.onMouseOver, P = "popupshown", void 0) :
+			(E = "mouseleave", H = this.onMouseOutput, P = "popuphidden", autoHideZoneAll && (this.toolboxOver = true), toolbox)
 		if (register) {
-			if (type) {
-				if (autoHideZoneAll) {
-					toolbox.addEventListener("mouseenter", this.onMouseOver, false);
-				} else {
-					PersonalToolbar.addEventListener("mouseenter", this.onMouseOver, false);
-					if (autoHideZoneNav) { try { navBar.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
-					if (autoHideZoneMenu) { try { toolbarmenubar.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
-					if (autoHideZoneTab) { try { TabsToolbar.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
-					if (autoHideZoneButton) { try { rbtlibbutton.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
-					if (autoHideZoneBackButton) { try { backButton.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
-					if (autoHideZoneMenuButton) { try { menuButton.addEventListener("mouseenter", this.onMouseOver, false); } catch (e) { } }
-				}
-				try { mainPopupSet.addEventListener("popupshown", MPSEventHandler, false); } catch (e) { }
-			} else {
-				try { toolbox.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { }
-				if (!autoHideZoneAll) {
-					PersonalToolbar.addEventListener("mouseleave", this.onMouseOutput, false);
-					if (autoHideZoneNav) { try { navBar.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { } }
-					if (autoHideZoneMenu) { try { toolbarmenubar.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { } }
-					if (autoHideZoneTab) { try { TabsToolbar.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { } }
-					if (autoHideZoneButton) { try { rbtlibbutton.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { } }
-					if (autoHideZoneBackButton) { try { backButton.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { } }
-					if (autoHideZoneMenuButton) { try { menuButton.addEventListener("mouseleave", this.onMouseOutput, false); } catch (e) { } }
-				} else roomybookmarkstoolbar.toolboxOver = true;
-				try { mainPopupSet.addEventListener("popuphidden", MPSEventHandler, false); } catch (e) { }
-			}
+			(autoHideZoneAll ? [toolbox] : [PersonalToolbar, T,
+				autoHideZoneNav			&& navBar || void 0,		autoHideZoneMenu		&& toolbarmenubar || void 0,
+				autoHideZoneTab			&& TabsToolbar || void 0,	autoHideZoneButton		&& rbtlibbutton || void 0,
+				autoHideZoneBackButton	&& backButton || void 0,	autoHideZoneMenuButton	&& menuButton || void 0])
+				.forEach(e => e?.addEventListener(E, H, false));
+			try { mainPopupSet.addEventListener(P, MPSEventHandler, false); } catch (e) { }
 		} else {
 			roomybookmarkstoolbar.mouseMoveListenerhandler(false);
-			if (type) {
-				PersonalToolbar.removeEventListener("mouseenter", this.onMouseOver, false);
-				try { navBar.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
-				try { toolbarmenubar.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
-				try { TabsToolbar.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
-				try { rbtlibbutton.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
-				try { backButton.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
-				try { menuButton.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
-				try { toolbox.removeEventListener("mouseenter", roomybookmarkstoolbar.onMouseOver, false); } catch (e) { }
-				try { mainPopupSet.removeEventListener("popupshown", MPSEventHandler, false); } catch (e) { }
-			} else {
-				PersonalToolbar.removeEventListener("mouseleave", this.onMouseOutput, false);
-				try { navBar.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
-				try { toolbarmenubar.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
-				try { TabsToolbar.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
-				try { rbtlibbutton.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
-				try { backButton.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
-				try { menuButton.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
-				try { toolbox.removeEventListener("mouseleave", roomybookmarkstoolbar.onMouseOutput, false); } catch (e) { }
-				try { mainPopupSet.removeEventListener("popuphidden", MPSEventHandler, false); } catch (e) { }
-			}
+			[toolbox, PersonalToolbar, navBar, toolbarmenubar, TabsToolbar, rbtlibbutton, backButton, menuButton]
+				.forEach(e => e?.removeEventListener(E, H, false));
+			try { mainPopupSet.removeEventListener(P, MPSEventHandler, false); } catch (e) { }
 		}
 	},
 

--- a/src/content/overlay.js
+++ b/src/content/overlay.js
@@ -190,30 +190,29 @@ var roomybookmarkstoolbar = {
 	},
 
 	eventListenerhandler: function (register, type) {
-		var autoHideZoneAll = this.branch.getBoolPref('autoHideZoneAll');
-		var autoHideZoneTab = this.branch.getBoolPref('autoHideZoneTab');
-		var autoHideZoneNav = this.branch.getBoolPref('autoHideZoneNav');
-		var autoHideZoneMenu = this.branch.getBoolPref('autoHideZoneMenu');
-		var autoHideZoneButton = this.branch.getBoolPref('autoHideZoneButton');
-		var autoHideZoneBackButton = this.branch.getBoolPref('autoHideZoneBackButton');
-		var autoHideZoneMenuButton = this.branch.getBoolPref('autoHideZoneMenuButton');
-		var toolbox = document.getElementById("navigator-toolbox");
-		var toolbarmenubar = document.getElementById("toolbar-menubar");
-		var TabsToolbar = document.getElementById("TabsToolbar");
-		var navBar = document.getElementById("nav-bar");
-		var rbtlibbutton = document.getElementById("rbtlibbutton");
-		var backButton = document.getElementById("back-button");
-		var menuButton = document.getElementById("PanelUI-menu-button");
-		var mainPopupSet = document.getElementById("mainPopupSet");
-		var MPSEventHandler = (e) => {if(["customizationui-widget-panel","placesContext"].includes(e.target.id)) this["on" + e.type]();};
+		let autoHideZoneAll = this.branch.getBoolPref('autoHideZoneAll');
+		let autoHideZoneTab = this.branch.getBoolPref('autoHideZoneTab');
+		let autoHideZoneNav = this.branch.getBoolPref('autoHideZoneNav');
+		let autoHideZoneMenu = this.branch.getBoolPref('autoHideZoneMenu');
+		let autoHideZoneButton = this.branch.getBoolPref('autoHideZoneButton');
+		let autoHideZoneBackButton = this.branch.getBoolPref('autoHideZoneBackButton');
+		let autoHideZoneMenuButton = this.branch.getBoolPref('autoHideZoneMenuButton');
+		let toolbox = document.getElementById("navigator-toolbox");
+		let toolbarmenubar = document.getElementById("toolbar-menubar");
+		let TabsToolbar = document.getElementById("TabsToolbar");
+		let navBar = document.getElementById("nav-bar");
+		let rbtlibbutton = document.getElementById("rbtlibbutton");
+		let backButton = document.getElementById("back-button");
+		let menuButton = document.getElementById("PanelUI-menu-button");
+		let mainPopupSet = document.getElementById("mainPopupSet");
+		let MPSEventHandler = (e) => {if(["customizationui-widget-panel","placesContext"].includes(e.target.id)) this["on" + e.type]();};
 
-		var E, H, P, T = type ? (E = "mouseenter", H = this.onMouseOver, P = "popupshown", void 0) :
+		let E, H, P, T = type ? (E = "mouseenter", H = this.onMouseOver, P = "popupshown", void 0) :
 			(E = "mouseleave", H = this.onMouseOutput, P = "popuphidden", autoHideZoneAll && (this.toolboxOver = true), toolbox)
 		if (register) {
 			(autoHideZoneAll ? [toolbox] : [PersonalToolbar, T,
-				autoHideZoneNav			&& navBar || void 0,		autoHideZoneMenu		&& toolbarmenubar || void 0,
-				autoHideZoneTab			&& TabsToolbar || void 0,	autoHideZoneButton		&& rbtlibbutton || void 0,
-				autoHideZoneBackButton	&& backButton || void 0,	autoHideZoneMenuButton	&& menuButton || void 0])
+				autoHideZoneNav	? navBar : void 0,		autoHideZoneMenu	? toolbarmenubar : void 0,	autoHideZoneBackButton ? backButton : void 0,
+				autoHideZoneTab	? TabsToolbar : void 0,	autoHideZoneButton	? rbtlibbutton : void 0,	autoHideZoneMenuButton ? menuButton : void 0])
 				.forEach(e => e?.addEventListener(E, H, false));
 			try { mainPopupSet.addEventListener(P, MPSEventHandler, false); } catch (e) { }
 		} else {

--- a/src/skin/css/main.css
+++ b/src/skin/css/main.css
@@ -19,7 +19,7 @@
 	}	
 
 	@media -moz-pref("extensions.roomybookmarkstoolbar.autoHideBar", true){
-		#PersonalToolbar[collapsed="true"] {
+		#PersonalToolbar[collapsed] {
 			visibility: hidden !important;
 		}
 	}

--- a/src/skin/css/overPage.css
+++ b/src/skin/css/overPage.css
@@ -1,21 +1,36 @@
 @namespace url(http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul);
 
 @-moz-document url(chrome://browser/content/browser.xhtml) {
-	#navigator-toolbox {
+	#navigator-toolbox:has(#PersonalToolbar:not([collapsed])),
+	#navigator-toolbox:has(#PersonalToolbar[collapsed="false"]) {
 		position: relative;
-		--browser-area-z-index-toolbox: 4;
+	}
+
+	#navigator-toolbox:has(#PersonalToolbar:not([collapsed])) ~ #browser,
+	#navigator-toolbox:has(#PersonalToolbar[collapsed="false"]) ~ #browser {
+		z-index: 0;
 	}
 
 	#PersonalToolbar {
 		position: absolute;
 		top: 100%;
 		width: 100% !important;
-		z-index: 2;
 		border-bottom-color: inherit;
 		border-bottom-left-radius: inherit;
 		border-bottom-right-radius: inherit;
 		border-bottom-style: inherit;
 		border-bottom-width: inherit;
 		border-collapse: inherit;
+	}
+
+	body,:not(body) {
+		--browser-stack-z-index-devtools-splitter: 2;
+		--browser-stack-z-index-dialog-stack: 3;
+		--browser-stack-z-index-rdm-toolbar: 4;
+		--browser-area-z-index-toolbox: 1;
+		--browser-area-z-index-sidebar: 2;
+		--browser-area-z-index-tabbox: 3;
+		--browser-area-z-index-sidebar-splitter: 4;
+		--browser-area-z-index-toolbox-while-animating: 5;
 	}
 }


### PR DESCRIPTION
Extension popup panel now got destroyed every time its closed so the event listener have to be on mainpopupset.
And I just combined context menu listener into it.

Also the fix for color menu breaks by inline event got banned.

@p1usminus I used a reordered z-index value set for bookmarksbar over page.
Which got mixed in here, decided if you want this method yourself.